### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/stopbars/Pilot-Client/security/code-scanning/1](https://github.com/stopbars/Pilot-Client/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, setting up .NET, restoring dependencies, and building the project, it does not require write permissions. We will set the `contents` permission to `read` at the workflow level, which will apply to all jobs unless overridden. This ensures minimal permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
