### PR TITLE
Improve debug mode animation and add simulator connection checks

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -847,18 +847,79 @@
 
         <!-- Debug Mode Indicator -->
         <Border Grid.Row="0"
-                Margin="0,0,0,0"
+                Margin="0,4,0,0"
                 Background="#CC0000"
                 CornerRadius="4"
                 Padding="10,5"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
-                Visibility="{Binding DebugModeVisibility}">
+                RenderTransformOrigin="1,0">
+            <Border.RenderTransform>
+                <ScaleTransform ScaleX="1" ScaleY="1"/>
+            </Border.RenderTransform>
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Opacity" Value="0"/>
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding DebugModeActive}" Value="True">
+                            <DataTrigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" To="1" Duration="0:0:0.2">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX" To="1" From="0.9" Duration="0:0:0.2">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY" To="1" From="0.9" Duration="0:0:0.2">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseOut"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.EnterActions>
+                            <DataTrigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" To="0" Duration="0:0:0.15">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseIn"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleX" To="0.9" Duration="0:0:0.15">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseIn"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <DoubleAnimation Storyboard.TargetProperty="RenderTransform.ScaleY" To="0.9" Duration="0:0:0.15">
+                                            <DoubleAnimation.EasingFunction>
+                                                <CubicEase EasingMode="EaseIn"/>
+                                            </DoubleAnimation.EasingFunction>
+                                        </DoubleAnimation>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.15" Value="{x:Static Visibility.Collapsed}"/>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.ExitActions>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="⚠"
                            FontSize="14"
                            Foreground="White"
-                           Margin="0,0,8,0"
+                           Margin="0,-2,8,0"
                            VerticalAlignment="Center"/>
                 <TextBlock Text="{Binding DebugModeText}"
                            FontWeight="Bold"

--- a/Presentation/ViewModels/MainWindowViewModel.cs
+++ b/Presentation/ViewModels/MainWindowViewModel.cs
@@ -50,6 +50,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
     private bool _debugModeActive;
     private int _debugStateId;
     private string? _debugPointId;
+    private string _debugModeTextCache = string.Empty;
     private int _selectedSimulatorIndex; // 0 = MSFS 2020, 1 = MSFS 2024
     private string? _msfsNeedsRestartSim;
 
@@ -118,7 +119,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
 
     public string OnGroundText => OnGround ? "On Ground" : "Airborne";
     public string SimulatorName { get => _simulatorName; set { if (value != _simulatorName) { _simulatorName = value; OnPropertyChanged(); } } }
-    public bool SimulatorConnected { get => _simConnected; set { if (value != _simConnected) { _simConnected = value; if (!value) _msfsNeedsRestartSim = null; OnPropertyChanged(); OnPropertyChanged(nameof(SimulatorConnectionText)); OnPropertyChanged(nameof(SimulatorStatusColor)); OnPropertyChanged(nameof(MsfsNeedsRestartVisibility)); OnPropertyChanged(nameof(MsfsNeedsRestartText)); } } }
+    public bool SimulatorConnected { get => _simConnected; set { if (value != _simConnected) { _simConnected = value; if (!value) { _msfsNeedsRestartSim = null; if (_debugModeActive) DebugModeActive = false; } OnPropertyChanged(); OnPropertyChanged(nameof(SimulatorConnectionText)); OnPropertyChanged(nameof(SimulatorStatusColor)); OnPropertyChanged(nameof(MsfsNeedsRestartVisibility)); OnPropertyChanged(nameof(MsfsNeedsRestartText)); } } }
     public string SimulatorConnectionText => SimulatorConnected ? "Connected" : "Disconnected";
     public string SimulatorStatusColor => SimulatorConnected ? "LimeGreen" : "Gray";
     public bool ServerConnected
@@ -164,7 +165,14 @@ public class MainWindowViewModel : INotifyPropertyChanged
             {
                 _debugModeActive = value;
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(DebugModeText));
+                
+                if (value)
+                {
+                    // Immediately update text when turning on
+                    UpdateDebugModeText();
+                }
+                // Text clears on next enable, not on disable (prevents text vanishing mid-animation)
+                
                 OnPropertyChanged(nameof(DebugModeVisibility));
             }
         }
@@ -182,7 +190,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
             {
                 _debugStateId = value;
                 OnPropertyChanged();
-                OnPropertyChanged(nameof(DebugModeText));
+                UpdateDebugModeText();
             }
         }
     }
@@ -190,9 +198,16 @@ public class MainWindowViewModel : INotifyPropertyChanged
     /// <summary>
     /// Text to display when debug mode is active.
     /// </summary>
-    public string DebugModeText => _debugModeActive
-        ? $"DEBUG MODE - State: {_debugStateId} (Press Ctrl+Shift+D to disable)"
-        : string.Empty;
+    public string DebugModeText => _debugModeTextCache;
+    
+    private void UpdateDebugModeText()
+    {
+        // Only update when active to prevent text flash during fade-out
+        if (!_debugModeActive) return;
+
+        _debugModeTextCache = $"Debug Mode  —  State: {_debugStateId}";
+        OnPropertyChanged(nameof(DebugModeText));
+    }
 
     /// <summary>
     /// Visibility of the debug mode indicator.
@@ -932,6 +947,7 @@ public class MainWindowViewModel : INotifyPropertyChanged
     /// </summary>
     public void ToggleDebugMode()
     {
+        if (!SimulatorConnected) return;
         _pointController?.ToggleDebugMode();
     }
 


### PR DESCRIPTION
## Summary
Adds smooth fade-in/fade-out animations to the debug mode indicator and implements simulator connection checks to ensure debug mode can only be activated when a simulator is connected.

## Changes Made
- Added smooth fade-in/fade-out animations to the debug mode indicator with opacity and scale transforms
- Implemented text caching mechanism (`_debugModeTextCache`) to prevent text from clearing during exit animation
- Modified `UpdateDebugModeText()` to only update when debug mode is active, avoiding text flash during fade-out
- Added guard in `ToggleDebugMode()` to prevent activation when simulator is disconnected
- Modified `SimulatorConnected` setter to auto-disable debug mode when simulator disconnects
- Adjusted warning icon vertical alignment (Margin="0,-2,8,0")
- Adjusted timing: 200ms fade-in, 150ms fade-out with proper easing functions

## Additional Information

## Author Information
**Discord Username:**
**VATSIM CID:** 

---

### Checklist:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?